### PR TITLE
Eliminada interferencia con el plugin 'harvest'

### DIFF
--- a/ckanext/facet_scheming/faceted.py
+++ b/ckanext/facet_scheming/faceted.py
@@ -26,8 +26,11 @@ class Faceted():
     def dataset_facets(self,
                        facets_dict,
                        package_type):
-
-        return self._custom_facets(facets_dict, package_type)
+        #this patch is necessary to avoid collisions with harvest package type from these plugin (harvest)
+        if package_type == "dataset":
+            return self._custom_facets(facets_dict, package_type)
+        else:
+            return facets_dict
 
     def _custom_facets(self,
                        facets_dict,

--- a/ckanext/facet_scheming/plugin.py
+++ b/ckanext/facet_scheming/plugin.py
@@ -26,8 +26,8 @@ class FacetSchemingPlugin(plugins.SingletonPlugin, Faceted, PackageController, D
         toolkit.add_template_directory(config_, 'templates')
         toolkit.add_public_directory(config_, 'public')
 
-        toolkit.add_resource('fanstatic',
-                             'facet_scheming')
+        #toolkit.add_resource('fanstatic',
+        #                     'facet_scheming')
 
         toolkit.add_resource('assets',
                              'ckanext-facet_scheming')


### PR DESCRIPTION
Existía un problema con el plugin de harvest, que necesita su propio set de facets en su página. Ha sido necesario comprobar el tipo de paquete (harvest) para evitar modificar la lista de facets al renderizar la plantilla 'search' de ese plugin.